### PR TITLE
Added Fullscreen mode for Graph Canvas

### DIFF
--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -33,13 +33,11 @@ export default function Graph({ result }: GraphProps) {
 
   // fullscreen function, on user clicking canvas
   const fullscreenToggle = () => {
-    const graphContainer = document.getElementById("graph-container");
-    if (graphContainer) {
-      if (!document.fullscreenElement) {
-        graphContainer.requestFullscreen()
-      } else {
-        document.exitFullscreen();
-      }
+    const graphContainer = document.getElementById("graph-container")!;
+    if (!document.fullscreenElement) {
+      graphContainer.requestFullscreen();
+    } else {
+      document.exitFullscreen();
     }
   };
 

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -11,6 +11,7 @@ export default function Graph({ result }: GraphProps) {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
 
+  // ADDING EDGEs AND NODES
   result.paths.forEach((path) => {
     for (let i = 0; i < path.length; i++){
       if (!nodes.some((node) => node.id === path[i])) {
@@ -30,16 +31,31 @@ export default function Graph({ result }: GraphProps) {
     }
   })
 
+  // fullscreen function, on user clicking canvas
+  const fullscreenToggle = () => {
+    const graphContainer = document.getElementById("graph-container");
+    if (graphContainer) {
+      if (!document.fullscreenElement) {
+        graphContainer.requestFullscreen()
+      } else {
+        document.exitFullscreen();
+      }
+    }
+  };
+
   return (
     <div id="graph-container">
       <div id="canvas-container">
       <GraphCanvas
+          // create the canvas (graph attributes)
           nodes = {nodes}
           edges= {edges}
           layoutType="treeLr2d" 
           animated={true} 
           edgeArrowPosition="end" 
           draggable={true}
+          onCanvasClick = {fullscreenToggle}
+          
         />
       </div>
       <div id="stats">
@@ -72,6 +88,7 @@ export default function Graph({ result }: GraphProps) {
           </tbody>
         </table>
       </div>
+      <div id="fullscreen-txt">Click Canvas to Enter Fullscreen</div>
       <span id="graph-description">Found {result.paths.length} paths with {result.shortest_degree} degrees of separation!</span>
     </div>
   );

--- a/frontend/src/styles/Graph.css
+++ b/frontend/src/styles/Graph.css
@@ -6,6 +6,20 @@
   margin-bottom: 40px;
 }
 
+#graph-container:fullscreen {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+#fullscreen-txt {
+  text-align: center;
+  font-size: 18px;
+  color: black;
+  margin-top: 10px;
+}
+
 #canvas-container {
   position: relative;
   aspect-ratio: 1;
@@ -35,6 +49,8 @@
 #graph-description {
   grid-column: span 2;
   padding: 10px;
+  padding-top: 20px;
   text-align: center;
   font-size: 20px;
+  font-weight: bold;
 }


### PR DESCRIPTION
### List of Changes

Added a fullscreen option for the graph canvas. Useful for large complex graphs.

![image](https://github.com/user-attachments/assets/ef3e1882-327e-439f-b8f4-28cf7a23788b)
![image](https://github.com/user-attachments/assets/4a826e44-df32-4973-9521-d9aac402ec01)


Can click the canvas again or press esc to exit fullscreen mode